### PR TITLE
updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,8 @@
 
 Easy and conventient way to handle revisions of your models within the database.
 
-* Handles the revisions in **bulk** - one entry covers all the created/updated fields, what makes it really **easy to 
+* Handles the revisions in **bulk** - one entry covers all the created/updated fields, what makes it really **easy to
 e.g., compare 2 given versions** or get all the data changed during one single transaction.
-
 
 ## Requirements
 
@@ -31,7 +30,7 @@ composer require johannesschobel/laravel-revisionable
 ### 3. Publish the package config file:
 
 ```
-~$ php artisan vendor:publish [--provider="JohannesSchobel\Revisionable\RevisionableServiceProvider"]
+php artisan vendor:publish --provider="JohannesSchobel\Revisionable\RevisionableServiceProvider"
 ```
 
 this will create `config/revisionable.php` file, where you can adjust a few settings.
@@ -55,7 +54,7 @@ use JohannesSchobel\Revisionable\Traits\Revisionable;
 class User extends Model
 {
     use Revisionable;
-}    
+}
 ```
 
 And that's all to get you started!
@@ -91,7 +90,7 @@ If you want to disable revisions for a specific model just add the following var
 
 ### Revision Cleanup
 
-You can further specify that you only want to clean up old revisions of a model. By doing so, you can further define, 
+You can further specify that you only want to clean up old revisions of a model. By doing so, you can further define,
 how many revisions of one model you would like to keep in your database (default is set to 20). Say, if you add the 21st
 revision, the first one is deleted.
 
@@ -103,11 +102,11 @@ You may customize this behaviour for each model by changing the variables
 
 ## Rollback (aka load old revisions)
 
-Of course, you can rollback to an old revision of your model. The `Trait` added earlier (e.g., the `Revisionable` trait) 
+Of course, you can rollback to an old revision of your model. The `Trait` added earlier (e.g., the `Revisionable` trait)
 already provides handy methods for you - so you don't need to worry about this.
 
-You can either use the `$model->rollbackToTimestamp($timestamp)` or `$model->rollbackSteps($steps)` functions for this 
-purpose. Note that there is a configuration flag `revisionable.rollback.cleanup` (default `false`) that indicates, 
+You can either use the `$model->rollbackToTimestamp($timestamp)` or `$model->rollbackSteps($steps)` functions for this
+purpose. Note that there is a configuration flag `revisionable.rollback.cleanup` (default `false`) that indicates,
 whether the revisions rolled back should be deleted (`true`) or not (`false`).
 
 Both functions return the rolled back model, which is already persisted in the database.
@@ -119,6 +118,9 @@ $ php artisan tinker
 
 >>> $ticket = App\Models\Ticket::first();
 => <App\Models\Ticket>
+
+>>> $revision = $ticket->revisions->first();
+=> $revision
 
 >>> $revision->getDiff();
 => [

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,13 @@
         "tymon/jwt-auth": "^0.5.3",
         "squizlabs/php_codesniffer": "~2.0"
     },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "JohannesSchobel\\Revisionable\\RevisionableServiceProvider"
+            ]
+        }
+    },
     "autoload": {
         "psr-0": {
             "JohannesSchobel\\Revisionable": "src/"

--- a/src/JohannesSchobel/Revisionable/Models/Revision.php
+++ b/src/JohannesSchobel/Revisionable/Models/Revision.php
@@ -26,7 +26,7 @@ class Revision extends Model
      * @var array
      */
     protected $fillable = [
-        'table_name', 'action', 'user_id', 'user', 'old',
+        'table_name', 'action', 'user_id', 'old',
         'new', 'ip', 'ip_forwarded',
     ];
 

--- a/src/JohannesSchobel/Revisionable/RevisionableServiceProvider.php
+++ b/src/JohannesSchobel/Revisionable/RevisionableServiceProvider.php
@@ -3,16 +3,18 @@
 namespace JohannesSchobel\Revisionable;
 
 use Illuminate\Support\ServiceProvider;
-use JohannesSchobel\Revisionable\Adapters;
-use JohannesSchobel\Revisionable\Interfaces\UserProvider;
 use JohannesSchobel\Revisionable\Models\Revision;
+use JohannesSchobel\Revisionable\Interfaces\UserProvider;
 
 class RevisionableServiceProvider extends ServiceProvider
 {
-    public function boot() {
+    public function boot()
+    {
         $this->publishes([
-            __DIR__.'/../../config/revisionable.php'   => config_path('revisionable.php'),
+            __DIR__ . '/../../config' => config_path(),
         ], 'config');
+
+        $this->loadMigrationsFrom(__DIR__ . '/../../migrations');
     }
 
     /**
@@ -26,9 +28,10 @@ class RevisionableServiceProvider extends ServiceProvider
     }
 
     /**
-     * Get the Configuration
+     * Get the Configuration.
      */
-    private function setupConfig() {
+    private function setupConfig()
+    {
         $this->mergeConfigFrom(realpath(__DIR__ . '/../../config/revisionable.php'), 'revisionable');
     }
 
@@ -60,6 +63,7 @@ class RevisionableServiceProvider extends ServiceProvider
                 $this->bindGuardProvider();
                 break;
         }
+
         $this->app->alias('revisionable.userprovider', UserProvider::class);
     }
 
@@ -70,6 +74,7 @@ class RevisionableServiceProvider extends ServiceProvider
     {
         $this->app->singleton('revisionable.userprovider', function ($app) {
             $field = $app['config']->get('revisionable.userfield');
+
             return new Adapters\Sentry($app['sentry'], $field);
         });
     }
@@ -81,6 +86,7 @@ class RevisionableServiceProvider extends ServiceProvider
     {
         $this->app->singleton('revisionable.userprovider', function ($app) {
             $field = $app['config']->get('revisionable.userfield');
+
             return new Adapters\Sentinel($app['sentinel'], $field);
         });
     }
@@ -92,6 +98,7 @@ class RevisionableServiceProvider extends ServiceProvider
     {
         $this->app->singleton('revisionable.userprovider', function ($app) {
             $field = $app['config']->get('revisionable.userfield');
+
             return new Adapters\JwtAuth($app['tymon.jwt.auth'], $field);
         });
     }
@@ -103,19 +110,19 @@ class RevisionableServiceProvider extends ServiceProvider
     {
         $this->app->singleton('revisionable.userprovider', function ($app) {
             $field = $app['config']->get('revisionable.userfield');
+
             return new Adapters\Guard($app['auth']->guard(), $field);
         });
     }
 
     /**
      * Bind adapter for Session to the IoC.
-     *
-     * @return void
      */
     protected function bindSessionProvider()
     {
         $this->app->singleton('revisionable.userprovider', function ($app) {
             $field = $app['config']->get('revisionable.userfield');
+
             return new Adapters\Session(session(), $field);
         });
     }
@@ -126,7 +133,7 @@ class RevisionableServiceProvider extends ServiceProvider
     protected function bootModel()
     {
         $table = $this->app['config']->get('revisionable.table', 'revisions');
-        $user = $this->app['config']->get('revisionable.usermodel', 'App\User');
+        $user  = $this->app['config']->get('revisionable.usermodel', 'App\User');
 
         forward_static_call_array([Revision::class, 'setCustomTable'], [$table]);
         forward_static_call_array([Revision::class, 'setUserModel'], [$user]);

--- a/src/JohannesSchobel/Revisionable/Traits/Revisionable.php
+++ b/src/JohannesSchobel/Revisionable/Traits/Revisionable.php
@@ -89,6 +89,9 @@ trait Revisionable
             $revisionsToDelete = $current->revisions()->where('id', '>=', $revision->id)->delete();
         }
 
+        // fire event
+        event('revisionable-rollingback', $current);
+
         $current->fill($revision->old);
         $current->save();
 

--- a/src/JohannesSchobel/Revisionable/Traits/Revisionable.php
+++ b/src/JohannesSchobel/Revisionable/Traits/Revisionable.php
@@ -191,7 +191,15 @@ trait Revisionable
      */
     public function getRevisionable()
     {
-        return property_exists($this, 'revisionable') ? (array) $this->revisionable : [];
+        if (!property_exists($this, 'revisionable') && property_exists($this, 'fillable')) {
+            return (array) $this->fillable;
+        }
+
+        if (property_exists($this, 'revisionable') && !property_exists($this, 'fillable')) {
+            return (array) $this->revisionable;
+        }
+
+        return array_merge($this->fillable, $this->revisionable);
     }
 
     /**
@@ -202,9 +210,16 @@ trait Revisionable
      */
     public function getNonRevisionable()
     {
-        return property_exists($this, 'nonRevisionable')
-                ? (array) $this->nonRevisionable
-                : ['created_at', 'updated_at', 'deleted_at'];
+        $nonRevisionable = property_exists($this, 'nonRevisionable')
+            ? (array) $this->nonRevisionable
+            : [];
+
+        return array_merge(
+            $nonRevisionable,
+            ['created_at', 'updated_at', 'deleted_at'],
+            $this->guarded,
+            $this->hidden
+        );
     }
 
     /**


### PR DESCRIPTION
- add auto-disc for laravel
- fix migration
- remove user from as its not needed
- add event for b4 saving, very importatnt incase the user have a translation system as now the revision data will be saved under the current locale instead of replacing the column value.
- add support to fillable, guarded, hidden
- dont save model `['created_at', 'updated_at', 'deleted_at’]` by default as revisionable already do that from its part
- update readme